### PR TITLE
Add lambda at edge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ distribution:
       - https://my-bucket.s3.amazonaws.com
 ```
 
-#### Complex origin objects
-
-You can extend your origins configuration by declaring them as objects. For example, to add cache behaviors:
+#### Custom cache behavior
 
 ```yml
 # serverless.yml
@@ -69,6 +67,23 @@ distribution:
         pathPatterns:
           /static/images: # route any /static/images requests to https://my-assets.com
             ttl: 10
+```
+
+#### Lambda@Edge
+
+```yml
+# serverless.yml
+
+distribution:
+  component: '@serverless/aws-cloudfront'
+  inputs:
+    origins:
+      - url: https://sampleorigin.com
+        pathPatterns:
+          /sample/path:
+            ttl: 10
+            lambda@edge:
+              viewer-request: arn:aws:lambda:us-east-1:123:function:myFunc:version # lambda ARN including version
 ```
 
 ### 4. Deploy

--- a/__tests__/__snapshots__/lambda-at-edge.test.js.snap
+++ b/__tests__/__snapshots__/lambda-at-edge.test.js.snap
@@ -1,0 +1,164 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Input origin as a custom url creates distribution with lambda associations for each event type 1`] = `
+Object {
+  "DistributionConfig": Object {
+    "Aliases": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "CacheBehaviors": Object {
+      "Items": Array [
+        Object {
+          "AllowedMethods": Object {
+            "CachedMethods": Object {
+              "Items": Array [
+                "GET",
+                "HEAD",
+              ],
+              "Quantity": 2,
+            },
+            "Items": Array [
+              "GET",
+              "HEAD",
+            ],
+            "Quantity": 2,
+          },
+          "Compress": true,
+          "DefaultTTL": 10,
+          "FieldLevelEncryptionId": "",
+          "ForwardedValues": Object {
+            "Cookies": Object {
+              "Forward": "all",
+            },
+            "Headers": Object {
+              "Items": Array [],
+              "Quantity": 0,
+            },
+            "QueryString": true,
+            "QueryStringCacheKeys": Object {
+              "Items": Array [],
+              "Quantity": 0,
+            },
+          },
+          "LambdaFunctionAssociations": Object {
+            "Items": Array [
+              Object {
+                "EventType": "viewer-request",
+                "IncludeBody": true,
+                "LambdaFunctionARN": "arn:aws:lambda:us-east-1:123:function:viewerRequestFunction",
+              },
+              Object {
+                "EventType": "origin-request",
+                "IncludeBody": true,
+                "LambdaFunctionARN": "arn:aws:lambda:us-east-1:123:function:originRequestFunction",
+              },
+              Object {
+                "EventType": "origin-response",
+                "IncludeBody": true,
+                "LambdaFunctionARN": "arn:aws:lambda:us-east-1:123:function:originResponseFunction",
+              },
+              Object {
+                "EventType": "viewer-response",
+                "IncludeBody": true,
+                "LambdaFunctionARN": "arn:aws:lambda:us-east-1:123:function:viewerResponseFunction",
+              },
+            ],
+            "Quantity": 1,
+          },
+          "MaxTTL": 10,
+          "MinTTL": 10,
+          "PathPattern": "/some/path",
+          "SmoothStreaming": false,
+          "TargetOriginId": "exampleorigin.com",
+          "TrustedSigners": Object {
+            "Enabled": false,
+            "Quantity": 0,
+          },
+          "ViewerProtocolPolicy": "https-only",
+        },
+      ],
+      "Quantity": 1,
+    },
+    "CallerReference": "1566599541192",
+    "Comment": "",
+    "DefaultCacheBehavior": Object {
+      "AllowedMethods": Object {
+        "CachedMethods": Object {
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Items": Array [
+          "HEAD",
+          "GET",
+        ],
+        "Quantity": 2,
+      },
+      "Compress": false,
+      "DefaultTTL": 86400,
+      "FieldLevelEncryptionId": "",
+      "ForwardedValues": Object {
+        "Cookies": Object {
+          "Forward": "none",
+        },
+        "Headers": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "QueryString": false,
+        "QueryStringCacheKeys": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+      },
+      "LambdaFunctionAssociations": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "MaxTTL": 31536000,
+      "MinTTL": 0,
+      "SmoothStreaming": false,
+      "TargetOriginId": "exampleorigin.com",
+      "TrustedSigners": Object {
+        "Enabled": false,
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "ViewerProtocolPolicy": "redirect-to-https",
+    },
+    "Enabled": true,
+    "HttpVersion": "http2",
+    "Origins": Object {
+      "Items": Array [
+        Object {
+          "CustomHeaders": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "CustomOriginConfig": Object {
+            "HTTPPort": 80,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginProtocolPolicy": "https-only",
+            "OriginReadTimeout": 30,
+            "OriginSslProtocols": Object {
+              "Items": Array [
+                "TLSv1.2",
+              ],
+              "Quantity": 1,
+            },
+          },
+          "DomainName": "exampleorigin.com",
+          "Id": "exampleorigin.com",
+          "OriginPath": "",
+        },
+      ],
+      "Quantity": 1,
+    },
+    "PriceClass": "PriceClass_All",
+  },
+}
+`;

--- a/__tests__/__snapshots__/lambda-at-edge.test.js.snap
+++ b/__tests__/__snapshots__/lambda-at-edge.test.js.snap
@@ -64,7 +64,7 @@ Object {
                 "LambdaFunctionARN": "arn:aws:lambda:us-east-1:123:function:viewerResponseFunction",
               },
             ],
-            "Quantity": 1,
+            "Quantity": 4,
           },
           "MaxTTL": 10,
           "MinTTL": 10,

--- a/__tests__/custom-url-origin.test.js
+++ b/__tests__/custom-url-origin.test.js
@@ -1,4 +1,4 @@
-const { createComponent } = require('../test-utils')
+const { createComponent, assertHasOrigin } = require('../test-utils')
 
 const {
   mockCreateDistribution,
@@ -26,36 +26,26 @@ describe('Input origin as a custom url', () => {
       origins: ['https://mycustomorigin.com']
     })
 
-    expect(mockCreateDistribution).toBeCalledWith(
-      expect.objectContaining({
-        DistributionConfig: expect.objectContaining({
-          Origins: expect.objectContaining({
-            Items: [
-              {
-                Id: 'mycustomorigin.com',
-                DomainName: 'mycustomorigin.com',
-                CustomOriginConfig: {
-                  HTTPPort: 80,
-                  HTTPSPort: 443,
-                  OriginProtocolPolicy: 'https-only',
-                  OriginSslProtocols: {
-                    Quantity: 1,
-                    Items: ['TLSv1.2']
-                  },
-                  OriginReadTimeout: 30,
-                  OriginKeepaliveTimeout: 5
-                },
-                CustomHeaders: {
-                  Quantity: 0,
-                  Items: []
-                },
-                OriginPath: ''
-              }
-            ]
-          })
-        })
-      })
-    )
+    assertHasOrigin(mockCreateDistribution, {
+      Id: 'mycustomorigin.com',
+      DomainName: 'mycustomorigin.com',
+      CustomOriginConfig: {
+        HTTPPort: 80,
+        HTTPSPort: 443,
+        OriginProtocolPolicy: 'https-only',
+        OriginSslProtocols: {
+          Quantity: 1,
+          Items: ['TLSv1.2']
+        },
+        OriginReadTimeout: 30,
+        OriginKeepaliveTimeout: 5
+      },
+      CustomHeaders: {
+        Quantity: 0,
+        Items: []
+      },
+      OriginPath: ''
+    })
     expect(mockCreateDistribution.mock.calls[0][0]).toMatchSnapshot()
   })
 
@@ -82,37 +72,26 @@ describe('Input origin as a custom url', () => {
       origins: ['https://mycustomoriginupdated.com']
     })
 
-    expect(mockUpdateDistribution).toBeCalledWith(
-      expect.objectContaining({
-        DistributionConfig: expect.objectContaining({
-          Origins: expect.objectContaining({
-            Items: [
-              {
-                Id: 'mycustomoriginupdated.com',
-                DomainName: 'mycustomoriginupdated.com',
-                CustomOriginConfig: {
-                  HTTPPort: 80,
-                  HTTPSPort: 443,
-                  OriginProtocolPolicy: 'https-only',
-                  OriginSslProtocols: {
-                    Quantity: 1,
-                    Items: ['TLSv1.2']
-                  },
-                  OriginReadTimeout: 30,
-                  OriginKeepaliveTimeout: 5
-                },
-                CustomHeaders: {
-                  Quantity: 0,
-                  Items: []
-                },
-                OriginPath: ''
-              }
-            ]
-          })
-        })
-      })
-    )
-
+    assertHasOrigin(mockUpdateDistribution, {
+      Id: 'mycustomoriginupdated.com',
+      DomainName: 'mycustomoriginupdated.com',
+      CustomOriginConfig: {
+        HTTPPort: 80,
+        HTTPSPort: 443,
+        OriginProtocolPolicy: 'https-only',
+        OriginSslProtocols: {
+          Quantity: 1,
+          Items: ['TLSv1.2']
+        },
+        OriginReadTimeout: 30,
+        OriginKeepaliveTimeout: 5
+      },
+      CustomHeaders: {
+        Quantity: 0,
+        Items: []
+      },
+      OriginPath: ''
+    })
     expect(mockUpdateDistribution.mock.calls[0][0]).toMatchSnapshot()
   })
 })

--- a/__tests__/lambda-at-edge.test.js
+++ b/__tests__/lambda-at-edge.test.js
@@ -38,7 +38,7 @@ describe('Input origin as a custom url', () => {
     assertHasCacheBehavior(mockCreateDistribution, {
       PathPattern: '/some/path',
       LambdaFunctionAssociations: {
-        Quantity: 1,
+        Quantity: 4,
         Items: [
           {
             EventType: 'viewer-request',

--- a/__tests__/lambda-at-edge.test.js
+++ b/__tests__/lambda-at-edge.test.js
@@ -1,0 +1,95 @@
+const { createComponent, assertCacheBehaviorContainsItem } = require('../test-utils')
+
+const { mockCreateDistribution, mockCreateDistributionPromise } = require('aws-sdk')
+
+describe('Input origin as a custom url', () => {
+  let component
+
+  beforeEach(async () => {
+    mockCreateDistributionPromise.mockResolvedValueOnce({
+      Distribution: {
+        Id: 'distribution123'
+      }
+    })
+
+    component = await createComponent()
+  })
+
+  it('creates distribution with lambda associations for each event type', async () => {
+    await component.default({
+      origins: [
+        {
+          url: 'https://exampleorigin.com',
+          pathPatterns: {
+            '/some/path': {
+              ttl: 10,
+              'lambda@edge': {
+                'viewer-request': 'arn:aws:lambda:us-east-1:123:function:viewerRequestFunction',
+                'origin-request': 'arn:aws:lambda:us-east-1:123:function:originRequestFunction',
+                'origin-response': 'arn:aws:lambda:us-east-1:123:function:originResponseFunction',
+                'viewer-response': 'arn:aws:lambda:us-east-1:123:function:viewerResponseFunction'
+              }
+            }
+          }
+        }
+      ]
+    })
+
+    assertCacheBehaviorContainsItem(mockCreateDistribution, {
+      PathPattern: '/some/path',
+      LambdaFunctionAssociations: {
+        Quantity: 1,
+        Items: [
+          {
+            EventType: 'viewer-request',
+            LambdaFunctionARN: 'arn:aws:lambda:us-east-1:123:function:viewerRequestFunction',
+            IncludeBody: true
+          },
+          {
+            EventType: 'origin-request',
+            LambdaFunctionARN: 'arn:aws:lambda:us-east-1:123:function:originRequestFunction',
+            IncludeBody: true
+          },
+          {
+            EventType: 'origin-response',
+            LambdaFunctionARN: 'arn:aws:lambda:us-east-1:123:function:originResponseFunction',
+            IncludeBody: true
+          },
+          {
+            EventType: 'viewer-response',
+            LambdaFunctionARN: 'arn:aws:lambda:us-east-1:123:function:viewerResponseFunction',
+            IncludeBody: true
+          }
+        ]
+      }
+    })
+
+    expect(mockCreateDistribution.mock.calls[0][0]).toMatchSnapshot()
+  })
+
+  it('throws error when event type provided is not valid', async () => {
+    expect.assertions(1)
+
+    try {
+      await component.default({
+        origins: [
+          {
+            url: 'https://exampleorigin.com',
+            pathPatterns: {
+              '/some/path': {
+                ttl: 10,
+                'lambda@edge': {
+                  'invalid-eventtype': 'arn:aws:lambda:us-east-1:123:function:viewerRequestFunction'
+                }
+              }
+            }
+          }
+        ]
+      })
+    } catch (err) {
+      expect(err.message).toEqual(
+        '"invalid-eventtype" is not a valid lambda trigger. See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-cloudfront-trigger-events.html for valid event types.'
+      )
+    }
+  })
+})

--- a/__tests__/lambda-at-edge.test.js
+++ b/__tests__/lambda-at-edge.test.js
@@ -1,4 +1,4 @@
-const { createComponent, assertCacheBehaviorContainsItem } = require('../test-utils')
+const { createComponent, assertCacheBehaviorsContainsItem } = require('../test-utils')
 
 const { mockCreateDistribution, mockCreateDistributionPromise } = require('aws-sdk')
 
@@ -35,7 +35,7 @@ describe('Input origin as a custom url', () => {
       ]
     })
 
-    assertCacheBehaviorContainsItem(mockCreateDistribution, {
+    assertCacheBehaviorsContainsItem(mockCreateDistribution, {
       PathPattern: '/some/path',
       LambdaFunctionAssociations: {
         Quantity: 1,

--- a/__tests__/lambda-at-edge.test.js
+++ b/__tests__/lambda-at-edge.test.js
@@ -1,4 +1,4 @@
-const { createComponent, assertCacheBehaviorsContainsItem } = require('../test-utils')
+const { createComponent, assertHasCacheBehavior } = require('../test-utils')
 
 const { mockCreateDistribution, mockCreateDistributionPromise } = require('aws-sdk')
 
@@ -35,7 +35,7 @@ describe('Input origin as a custom url', () => {
       ]
     })
 
-    assertCacheBehaviorsContainsItem(mockCreateDistribution, {
+    assertHasCacheBehavior(mockCreateDistribution, {
       PathPattern: '/some/path',
       LambdaFunctionAssociations: {
         Quantity: 1,

--- a/__tests__/origin-with-path-pattern.test.js
+++ b/__tests__/origin-with-path-pattern.test.js
@@ -1,4 +1,4 @@
-const { createComponent } = require('../test-utils')
+const { createComponent, assertHasCacheBehavior, assertHasOrigin } = require('../test-utils')
 
 const {
   mockCreateDistribution,
@@ -35,29 +35,17 @@ describe('Input origin with path pattern', () => {
       ]
     })
 
-    expect(mockCreateDistribution).toBeCalledWith(
-      expect.objectContaining({
-        DistributionConfig: expect.objectContaining({
-          Origins: expect.objectContaining({
-            Items: [
-              expect.objectContaining({
-                Id: 'exampleorigin.com',
-                DomainName: 'exampleorigin.com'
-              })
-            ]
-          }),
-          CacheBehaviors: expect.objectContaining({
-            Items: [
-              expect.objectContaining({
-                PathPattern: '/some/path',
-                MinTTL: 10,
-                TargetOriginId: 'exampleorigin.com'
-              })
-            ]
-          })
-        })
-      })
-    )
+    assertHasOrigin(mockCreateDistribution, {
+      Id: 'exampleorigin.com',
+      DomainName: 'exampleorigin.com'
+    })
+
+    assertHasCacheBehavior(mockCreateDistribution, {
+      PathPattern: '/some/path',
+      MinTTL: 10,
+      TargetOriginId: 'exampleorigin.com'
+    })
+
     expect(mockCreateDistribution.mock.calls[0][0]).toMatchSnapshot()
   })
 
@@ -102,29 +90,16 @@ describe('Input origin with path pattern', () => {
       ]
     })
 
-    expect(mockUpdateDistribution).toBeCalledWith(
-      expect.objectContaining({
-        DistributionConfig: expect.objectContaining({
-          Origins: expect.objectContaining({
-            Items: [
-              expect.objectContaining({
-                Id: 'exampleorigin.com',
-                DomainName: 'exampleorigin.com'
-              })
-            ]
-          }),
-          CacheBehaviors: expect.objectContaining({
-            Items: [
-              expect.objectContaining({
-                PathPattern: '/some/other/path',
-                MinTTL: 10,
-                TargetOriginId: 'exampleorigin.com'
-              })
-            ]
-          })
-        })
-      })
-    )
+    assertHasOrigin(mockUpdateDistribution, {
+      Id: 'exampleorigin.com',
+      DomainName: 'exampleorigin.com'
+    })
+
+    assertHasCacheBehavior(mockUpdateDistribution, {
+      PathPattern: '/some/other/path',
+      MinTTL: 10,
+      TargetOriginId: 'exampleorigin.com'
+    })
 
     expect(mockUpdateDistribution.mock.calls[0][0]).toMatchSnapshot()
   })

--- a/__tests__/s3-origin.test.js
+++ b/__tests__/s3-origin.test.js
@@ -6,7 +6,7 @@ const {
   mockUpdateDistributionPromise
 } = require('aws-sdk')
 
-const { createComponent } = require('../test-utils')
+const { createComponent, assertHasOrigin } = require('../test-utils')
 
 describe('Input origin as an S3 bucket url', () => {
   let component
@@ -26,28 +26,19 @@ describe('Input origin as an S3 bucket url', () => {
       origins: ['https://mybucket.s3.amazonaws.com']
     })
 
-    expect(mockCreateDistribution).toBeCalledWith(
-      expect.objectContaining({
-        DistributionConfig: expect.objectContaining({
-          Origins: expect.objectContaining({
-            Items: [
-              {
-                Id: 'mybucket',
-                DomainName: 'mybucket.s3.amazonaws.com',
-                S3OriginConfig: {
-                  OriginAccessIdentity: ''
-                },
-                CustomHeaders: {
-                  Quantity: 0,
-                  Items: []
-                },
-                OriginPath: ''
-              }
-            ]
-          })
-        })
-      })
-    )
+    assertHasOrigin(mockCreateDistribution, {
+      Id: 'mybucket',
+      DomainName: 'mybucket.s3.amazonaws.com',
+      S3OriginConfig: {
+        OriginAccessIdentity: ''
+      },
+      CustomHeaders: {
+        Quantity: 0,
+        Items: []
+      },
+      OriginPath: ''
+    })
+
     expect(mockCreateDistribution.mock.calls[0][0]).toMatchSnapshot()
   })
 
@@ -74,20 +65,10 @@ describe('Input origin as an S3 bucket url', () => {
       origins: ['https://anotherbucket.s3.amazonaws.com']
     })
 
-    expect(mockUpdateDistribution).toBeCalledWith(
-      expect.objectContaining({
-        DistributionConfig: expect.objectContaining({
-          Origins: expect.objectContaining({
-            Items: [
-              expect.objectContaining({
-                Id: 'anotherbucket',
-                DomainName: 'anotherbucket.s3.amazonaws.com'
-              })
-            ]
-          })
-        })
-      })
-    )
+    assertHasOrigin(mockUpdateDistribution, {
+      Id: 'anotherbucket',
+      DomainName: 'anotherbucket.s3.amazonaws.com'
+    })
 
     expect(mockUpdateDistribution.mock.calls[0][0]).toMatchSnapshot()
   })

--- a/lib/parseInputOrigins.js
+++ b/lib/parseInputOrigins.js
@@ -35,7 +35,8 @@ module.exports = (origins) => {
             )
           }
 
-          cacheBehavior.LambdaFunctionAssociations.Quantity = 1
+          cacheBehavior.LambdaFunctionAssociations.Quantity =
+            cacheBehavior.LambdaFunctionAssociations.Quantity + 1
           cacheBehavior.LambdaFunctionAssociations.Items.push({
             EventType: eventType,
             LambdaFunctionARN: lambdaAtEdge[eventType],

--- a/lib/parseInputOrigins.js
+++ b/lib/parseInputOrigins.js
@@ -1,6 +1,12 @@
 const getOriginConfig = require('./getOriginConfig')
 const getCacheBehavior = require('./getCacheBehavior')
 
+const validLambdaTriggers = [
+  'viewer-request',
+  'origin-request',
+  'origin-response',
+  'viewer-response'
+]
 module.exports = (origins) => {
   const distributionOrigins = {
     Quantity: 0,
@@ -17,16 +23,31 @@ module.exports = (origins) => {
     if (typeof origin === 'object') {
       // add any cache behaviors
       for (const pathPattern in origin.pathPatterns) {
-        const cacheBehavior = getCacheBehavior(
-          pathPattern,
-          origin.pathPatterns[pathPattern],
-          originConfig.Id
-        )
+        const pathPatternConfig = origin.pathPatterns[pathPattern]
+        const cacheBehavior = getCacheBehavior(pathPattern, pathPatternConfig, originConfig.Id)
+
+        const lambdaAtEdge = pathPatternConfig['lambda@edge'] || {}
+
+        Object.keys(lambdaAtEdge).forEach((eventType) => {
+          if (!validLambdaTriggers.includes(eventType)) {
+            throw new Error(
+              `"${eventType}" is not a valid lambda trigger. See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-cloudfront-trigger-events.html for valid event types.`
+            )
+          }
+
+          cacheBehavior.LambdaFunctionAssociations.Quantity = 1
+          cacheBehavior.LambdaFunctionAssociations.Items.push({
+            EventType: eventType,
+            LambdaFunctionARN: lambdaAtEdge[eventType],
+            IncludeBody: true
+          })
+        })
 
         distributionCacheBehaviors = {
           Quantity: 0,
           Items: []
         }
+
         distributionCacheBehaviors.Quantity = distributionCacheBehaviors.Quantity + 1
         distributionCacheBehaviors.Items.push(cacheBehavior)
       }

--- a/test-utils.js
+++ b/test-utils.js
@@ -18,5 +18,17 @@ module.exports = {
     await component.init()
 
     return component
+  },
+
+  assertCacheBehaviorContainsItem: (spy, item) => {
+    expect(spy).toBeCalledWith(
+      expect.objectContaining({
+        DistributionConfig: expect.objectContaining({
+          CacheBehaviors: expect.objectContaining({
+            Items: [expect.objectContaining(item)]
+          })
+        })
+      })
+    )
   }
 }

--- a/test-utils.js
+++ b/test-utils.js
@@ -20,12 +20,24 @@ module.exports = {
     return component
   },
 
-  assertCacheBehaviorsContainsItem: (spy, item) => {
+  assertHasCacheBehavior: (spy, cacheBehavior) => {
     expect(spy).toBeCalledWith(
       expect.objectContaining({
         DistributionConfig: expect.objectContaining({
           CacheBehaviors: expect.objectContaining({
-            Items: [expect.objectContaining(item)]
+            Items: [expect.objectContaining(cacheBehavior)]
+          })
+        })
+      })
+    )
+  },
+
+  assertHasOrigin: (spy, origin) => {
+    expect(spy).toBeCalledWith(
+      expect.objectContaining({
+        DistributionConfig: expect.objectContaining({
+          Origins: expect.objectContaining({
+            Items: [expect.objectContaining(origin)]
           })
         })
       })

--- a/test-utils.js
+++ b/test-utils.js
@@ -20,7 +20,7 @@ module.exports = {
     return component
   },
 
-  assertCacheBehaviorContainsItem: (spy, item) => {
+  assertCacheBehaviorsContainsItem: (spy, item) => {
     expect(spy).toBeCalledWith(
       expect.objectContaining({
         DistributionConfig: expect.objectContaining({


### PR DESCRIPTION
Adds support for CloudFront lambda event triggers:

For example:

```yml
# serverless.yml

distribution:
  component: '@serverless/aws-cloudfront'
  inputs:
    origins:
      - url: https://sampleorigin.com
        pathPatterns:
          /sample/path:
            ttl: 10
            lambda@edge:
              viewer-request: arn:aws:lambda:us-east-1:123:function:myFunc:5 # lambda ARN including version
```

Event types supported: `viewer-request` | `origin-request` | `viewer-response` | `origin-response`

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-cloudfront-trigger-events.html

In future you may want to consider provisioning the Lambda as part of the `aws-cloudfront` component.  That could be another iteration of the API, for example by setting an object rather than the ARN string:

```yml
lambda@edge:
     viewer-request:
       code: ./edge-src
       handler: ./my-handler.js
```
