### PR TITLE
add configurable defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ distribution:
   inputs:
     region: us-east-1
     enabled: true # optional
+    defaults: # optional
+      ttl: 15
     origins:
       - https://my-bucket.s3.amazonaws.com
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ distribution:
     enabled: true # optional
     defaults: # optional
       ttl: 15
+      lambda@edge: # added to cloudfront default cache behavior
+        viewer-request: arn:aws:lambda:us-east-1:123:function:myFunc:version
     origins:
       - https://my-bucket.s3.amazonaws.com
 ```

--- a/__tests__/__snapshots__/custom-url-origin.test.js.snap
+++ b/__tests__/__snapshots__/custom-url-origin.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Input origin as a custom url creates distribution with custom url origin 1`] = `
+exports[`Input origin as a custom url creates distribution with custom url origin and sets defaults 1`] = `
 Object {
   "DistributionConfig": Object {
     "Aliases": Object {
@@ -25,7 +25,7 @@ Object {
         "Quantity": 2,
       },
       "Compress": false,
-      "DefaultTTL": 86400,
+      "DefaultTTL": 10,
       "FieldLevelEncryptionId": "",
       "ForwardedValues": Object {
         "Cookies": Object {
@@ -42,8 +42,14 @@ Object {
         },
       },
       "LambdaFunctionAssociations": Object {
-        "Items": Array [],
-        "Quantity": 0,
+        "Items": Array [
+          Object {
+            "EventType": "origin-request",
+            "IncludeBody": true,
+            "LambdaFunctionARN": "arn:aws:lambda:us-east-1:123:function:originRequestFunction",
+          },
+        ],
+        "Quantity": 1,
       },
       "MaxTTL": 31536000,
       "MinTTL": 0,

--- a/__tests__/custom-url-origin.test.js
+++ b/__tests__/custom-url-origin.test.js
@@ -21,8 +21,14 @@ describe('Input origin as a custom url', () => {
     component = await createComponent()
   })
 
-  it('creates distribution with custom url origin', async () => {
+  it('creates distribution with custom url origin and sets defaults', async () => {
     await component.default({
+      defaults: {
+        ttl: 10,
+        'lambda@edge': {
+          'origin-request': 'arn:aws:lambda:us-east-1:123:function:originRequestFunction'
+        }
+      },
       origins: ['https://mycustomorigin.com']
     })
 

--- a/lib/addLambdaAtEdgeToCacheBehavior.js
+++ b/lib/addLambdaAtEdgeToCacheBehavior.js
@@ -1,0 +1,25 @@
+const validLambdaTriggers = [
+  'viewer-request',
+  'origin-request',
+  'origin-response',
+  'viewer-response'
+]
+
+// adds lambda@edge to cache behavior passed
+module.exports = (cacheBehavior, lambdaAtEdgeConfig = {}) => {
+  Object.keys(lambdaAtEdgeConfig).forEach((eventType) => {
+    if (!validLambdaTriggers.includes(eventType)) {
+      throw new Error(
+        `"${eventType}" is not a valid lambda trigger. See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-cloudfront-trigger-events.html for valid event types.`
+      )
+    }
+
+    cacheBehavior.LambdaFunctionAssociations.Quantity =
+      cacheBehavior.LambdaFunctionAssociations.Quantity + 1
+    cacheBehavior.LambdaFunctionAssociations.Items.push({
+      EventType: eventType,
+      LambdaFunctionARN: lambdaAtEdgeConfig[eventType],
+      IncludeBody: true
+    })
+  })
+}

--- a/lib/getDefaultCacheBehavior.js
+++ b/lib/getDefaultCacheBehavior.js
@@ -1,5 +1,7 @@
+const addLambdaAtEdgeToCacheBehavior = require('./addLambdaAtEdgeToCacheBehavior')
+
 module.exports = (originId, defaults = {}) => {
-  return {
+  const defaultCacheBehavior = {
     TargetOriginId: originId,
     ForwardedValues: {
       QueryString: false,
@@ -40,4 +42,8 @@ module.exports = (originId, defaults = {}) => {
     },
     FieldLevelEncryptionId: ''
   }
+
+  addLambdaAtEdgeToCacheBehavior(defaultCacheBehavior, defaults['lambda@edge'])
+
+  return defaultCacheBehavior
 }

--- a/lib/getDefaultCacheBehavior.js
+++ b/lib/getDefaultCacheBehavior.js
@@ -1,4 +1,4 @@
-module.exports = (originId) => {
+module.exports = (originId, defaults = {}) => {
   return {
     TargetOriginId: originId,
     ForwardedValues: {
@@ -31,7 +31,7 @@ module.exports = (originId) => {
       }
     },
     SmoothStreaming: false,
-    DefaultTTL: 86400,
+    DefaultTTL: defaults.ttl || 86400,
     MaxTTL: 31536000,
     Compress: false,
     LambdaFunctionAssociations: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,10 @@ const createCloudFrontDistribution = async (cf, inputs) => {
   distributionConfig.Origins = Origins
 
   // set first origin declared as the default cache behavior
-  distributionConfig.DefaultCacheBehavior = getDefaultCacheBehavior(Origins.Items[0].Id)
+  distributionConfig.DefaultCacheBehavior = getDefaultCacheBehavior(
+    Origins.Items[0].Id,
+    inputs.defaults
+  )
 
   if (CacheBehaviors) {
     distributionConfig.CacheBehaviors = CacheBehaviors
@@ -65,7 +68,10 @@ const updateCloudFrontDistribution = async (cf, distributionId, inputs) => {
 
   const { Origins, CacheBehaviors } = parseInputOrigins(inputs.origins)
 
-  params.DistributionConfig.DefaultCacheBehavior = getDefaultCacheBehavior(Origins.Items[0].Id)
+  params.DistributionConfig.DefaultCacheBehavior = getDefaultCacheBehavior(
+    Origins.Items[0].Id,
+    inputs.defaults
+  )
   params.DistributionConfig.Origins = Origins
 
   if (CacheBehaviors) {

--- a/lib/parseInputOrigins.js
+++ b/lib/parseInputOrigins.js
@@ -1,12 +1,7 @@
 const getOriginConfig = require('./getOriginConfig')
 const getCacheBehavior = require('./getCacheBehavior')
+const addLambdaAtEdgeToCacheBehavior = require('./addLambdaAtEdgeToCacheBehavior')
 
-const validLambdaTriggers = [
-  'viewer-request',
-  'origin-request',
-  'origin-response',
-  'viewer-response'
-]
 module.exports = (origins) => {
   const distributionOrigins = {
     Quantity: 0,
@@ -26,23 +21,7 @@ module.exports = (origins) => {
         const pathPatternConfig = origin.pathPatterns[pathPattern]
         const cacheBehavior = getCacheBehavior(pathPattern, pathPatternConfig, originConfig.Id)
 
-        const lambdaAtEdge = pathPatternConfig['lambda@edge'] || {}
-
-        Object.keys(lambdaAtEdge).forEach((eventType) => {
-          if (!validLambdaTriggers.includes(eventType)) {
-            throw new Error(
-              `"${eventType}" is not a valid lambda trigger. See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-cloudfront-trigger-events.html for valid event types.`
-            )
-          }
-
-          cacheBehavior.LambdaFunctionAssociations.Quantity =
-            cacheBehavior.LambdaFunctionAssociations.Quantity + 1
-          cacheBehavior.LambdaFunctionAssociations.Items.push({
-            EventType: eventType,
-            LambdaFunctionARN: lambdaAtEdge[eventType],
-            IncludeBody: true
-          })
-        })
+        addLambdaAtEdgeToCacheBehavior(cacheBehavior, pathPatternConfig['lambda@edge'])
 
         distributionCacheBehaviors = {
           Quantity: 0,

--- a/serverless.js
+++ b/serverless.js
@@ -31,7 +31,10 @@ class CloudFront extends Component {
     })
 
     if (this.state.id) {
-      if (!equals(this.state.origins, inputs.origins)) {
+      if (
+        !equals(this.state.origins, inputs.origins) ||
+        !equals(this.state.defaults, inputs.defaults)
+      ) {
         this.context.debug(`Updating CloudFront distribution of ID ${this.state.id}.`)
         this.state = await updateCloudFrontDistribution(cf, this.state.id, inputs)
       }
@@ -42,6 +45,7 @@ class CloudFront extends Component {
 
     this.state.region = inputs.region
     this.state.origins = inputs.origins
+    this.state.defaults = inputs.defaults
     await this.save()
 
     this.context.debug(`CloudFront deployed successfully with URL: ${this.state.url}.`)


### PR DESCRIPTION
**Motivation**

Currently is not possible to configure the TTL or Lambda@Edge for  the default cache behavior .

**Proposal**

This PR introduces a new component input called `defaults`. You can pass a TTL or Lambda@Edge configuration used by the default cache behavior. Future defaults can be added here as well. 