### PR TITLE
add configurable allowed http methods for cache behaviors

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ distribution:
         pathPatterns:
           /static/images: # route any /static/images requests to https://my-assets.com
             ttl: 10
+            allowedHttpMethods: ['GET', 'HEAD'] # optional
 ```
 
 #### Lambda@Edge

--- a/__tests__/__snapshots__/origin-with-path-pattern.test.js.snap
+++ b/__tests__/__snapshots__/origin-with-path-pattern.test.js.snap
@@ -21,8 +21,9 @@ Object {
             "Items": Array [
               "GET",
               "HEAD",
+              "POST",
             ],
-            "Quantity": 2,
+            "Quantity": 3,
           },
           "Compress": true,
           "DefaultTTL": 10,

--- a/__tests__/origin-with-path-pattern.test.js
+++ b/__tests__/origin-with-path-pattern.test.js
@@ -28,7 +28,8 @@ describe('Input origin with path pattern', () => {
           url: 'https://exampleorigin.com',
           pathPatterns: {
             '/some/path': {
-              ttl: 10
+              ttl: 10,
+              allowedHttpMethods: ['GET', 'HEAD', 'POST']
             }
           }
         }

--- a/lib/getCacheBehavior.js
+++ b/lib/getCacheBehavior.js
@@ -1,5 +1,6 @@
 module.exports = (pathPattern, pathPatternConfig, originId) => {
-  const { ttl } = pathPatternConfig
+  const { ttl, allowedHttpMethods } = pathPatternConfig
+  const allowedMethods = allowedHttpMethods || ['GET', 'HEAD']
 
   return {
     ForwardedValues: {
@@ -25,8 +26,8 @@ module.exports = (pathPattern, pathPatternConfig, originId) => {
     },
     ViewerProtocolPolicy: 'https-only',
     AllowedMethods: {
-      Quantity: 2,
-      Items: ['GET', 'HEAD'],
+      Quantity: allowedMethods.length,
+      Items: allowedMethods,
       CachedMethods: {
         Items: ['GET', 'HEAD'],
         Quantity: 2


### PR DESCRIPTION
Currently is possible to configure allowed http methods for the default cache behavior. This allows the same for custom cache behaviors. 
Solves part of https://github.com/serverless-components/aws-cloudfront/issues/6