### PR TITLE
Expose more cache behavior parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ distribution:
     defaults: # optional
       ttl: 15
       allowedHttpMethods: ['HEAD', 'GET']
+      forward: # optional
+        # array of header names, 'none' or 'all'
+        headers: ['Accept', 'Accept-Language']
+        # array of cookie names, 'none' or 'all'
+        cookies: ['my-cookie]
+        queryString: true
+        queryStringCacheKeys: ['queryKey']
+      viewerProtocolPolicy: 'https-only' # optional
+      smoothStreaming: true # optional
+      compress: true # optional
+      fieldLevelEncryptionId: '123' # optional
       lambda@edge: # added to cloudfront default cache behavior
         viewer-request: arn:aws:lambda:us-east-1:123:function:myFunc:version
     origins:
@@ -60,7 +71,7 @@ distribution:
 ```
 
 #### Custom cache behavior
-
+Custom cache behaviors support the same config parameters as the default cache behavior (see the example above). 
 ```yml
 # serverless.yml
 
@@ -73,6 +84,12 @@ distribution:
           /static/images: # route any /static/images requests to https://my-assets.com
             ttl: 10
             allowedHttpMethods: ['GET', 'HEAD'] # optional
+            forward: # optional
+              headers: 'all' 
+              cookies: ['auth-token']
+              queryString: true
+            compress: false # optional
+            # ...
 ```
 
 #### Lambda@Edge

--- a/__tests__/__snapshots__/cache-behavior-options.test.js.snap
+++ b/__tests__/__snapshots__/cache-behavior-options.test.js.snap
@@ -1,0 +1,255 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Input origin as a custom url creates distribution with custom behavior options 1`] = `
+Object {
+  "DistributionConfig": Object {
+    "Aliases": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "CacheBehaviors": Object {
+      "Items": Array [
+        Object {
+          "AllowedMethods": Object {
+            "CachedMethods": Object {
+              "Items": Array [
+                "GET",
+                "HEAD",
+              ],
+              "Quantity": 2,
+            },
+            "Items": Array [
+              "GET",
+              "HEAD",
+            ],
+            "Quantity": 2,
+          },
+          "Compress": false,
+          "DefaultTTL": 0,
+          "FieldLevelEncryptionId": "321",
+          "ForwardedValues": Object {
+            "Cookies": Object {
+              "Forward": "whitelist",
+              "WhitelistedNames": Object {
+                "Items": Array [
+                  "auth-token",
+                ],
+                "Quantity": 1,
+              },
+            },
+            "Headers": Object {
+              "Items": Array [
+                "*",
+              ],
+              "Quantity": 1,
+            },
+            "QueryString": true,
+            "QueryStringCacheKeys": Object {
+              "Items": Array [],
+              "Quantity": 0,
+            },
+          },
+          "LambdaFunctionAssociations": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "MaxTTL": 0,
+          "MinTTL": 0,
+          "PathPattern": "/sample/path",
+          "SmoothStreaming": false,
+          "TargetOriginId": "mycustomorigin.com",
+          "TrustedSigners": Object {
+            "Enabled": false,
+            "Quantity": 0,
+          },
+          "ViewerProtocolPolicy": "redirect-to-https",
+        },
+      ],
+      "Quantity": 1,
+    },
+    "CallerReference": "1566599541192",
+    "Comment": "",
+    "DefaultCacheBehavior": Object {
+      "AllowedMethods": Object {
+        "CachedMethods": Object {
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Items": Array [
+          "HEAD",
+          "GET",
+        ],
+        "Quantity": 2,
+      },
+      "Compress": false,
+      "DefaultTTL": 0,
+      "FieldLevelEncryptionId": "",
+      "ForwardedValues": Object {
+        "Cookies": Object {
+          "Forward": "none",
+        },
+        "Headers": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "QueryString": false,
+        "QueryStringCacheKeys": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+      },
+      "LambdaFunctionAssociations": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "MaxTTL": 31536000,
+      "MinTTL": 0,
+      "SmoothStreaming": false,
+      "TargetOriginId": "mycustomorigin.com",
+      "TrustedSigners": Object {
+        "Enabled": false,
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "ViewerProtocolPolicy": "redirect-to-https",
+    },
+    "Enabled": true,
+    "HttpVersion": "http2",
+    "Origins": Object {
+      "Items": Array [
+        Object {
+          "CustomHeaders": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "CustomOriginConfig": Object {
+            "HTTPPort": 80,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginProtocolPolicy": "https-only",
+            "OriginReadTimeout": 30,
+            "OriginSslProtocols": Object {
+              "Items": Array [
+                "TLSv1.2",
+              ],
+              "Quantity": 1,
+            },
+          },
+          "DomainName": "mycustomorigin.com",
+          "Id": "mycustomorigin.com",
+          "OriginPath": "",
+        },
+      ],
+      "Quantity": 1,
+    },
+    "PriceClass": "PriceClass_All",
+  },
+}
+`;
+
+exports[`Input origin as a custom url creates distribution with custom default behavior options 1`] = `
+Object {
+  "DistributionConfig": Object {
+    "Aliases": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "CacheBehaviors": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "CallerReference": "1566599541192",
+    "Comment": "",
+    "DefaultCacheBehavior": Object {
+      "AllowedMethods": Object {
+        "CachedMethods": Object {
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Items": Array [
+          "GET",
+          "HEAD",
+          "OPTIONS",
+          "PUT",
+          "POST",
+          "PATCH",
+          "DELETE",
+        ],
+        "Quantity": 7,
+      },
+      "Compress": true,
+      "DefaultTTL": 0,
+      "FieldLevelEncryptionId": "123",
+      "ForwardedValues": Object {
+        "Cookies": Object {
+          "Forward": "all",
+        },
+        "Headers": Object {
+          "Items": Array [
+            "Accept",
+            "Accept-Language",
+          ],
+          "Quantity": 2,
+        },
+        "QueryString": true,
+        "QueryStringCacheKeys": Object {
+          "Items": Array [
+            "query",
+          ],
+          "Quantity": 1,
+        },
+      },
+      "LambdaFunctionAssociations": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "MaxTTL": 31536000,
+      "MinTTL": 0,
+      "SmoothStreaming": true,
+      "TargetOriginId": "mycustomorigin.com",
+      "TrustedSigners": Object {
+        "Enabled": false,
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "ViewerProtocolPolicy": "https-only",
+    },
+    "Enabled": true,
+    "HttpVersion": "http2",
+    "Origins": Object {
+      "Items": Array [
+        Object {
+          "CustomHeaders": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "CustomOriginConfig": Object {
+            "HTTPPort": 80,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginProtocolPolicy": "https-only",
+            "OriginReadTimeout": 30,
+            "OriginSslProtocols": Object {
+              "Items": Array [
+                "TLSv1.2",
+              ],
+              "Quantity": 1,
+            },
+          },
+          "DomainName": "mycustomorigin.com",
+          "Id": "mycustomorigin.com",
+          "OriginPath": "",
+        },
+      ],
+      "Quantity": 1,
+    },
+    "PriceClass": "PriceClass_All",
+  },
+}
+`;

--- a/__tests__/cache-behavior-options.test.js
+++ b/__tests__/cache-behavior-options.test.js
@@ -1,0 +1,68 @@
+const { createComponent } = require('../test-utils')
+
+const { mockCreateDistribution, mockCreateDistributionPromise } = require('aws-sdk')
+
+describe('Input origin as a custom url', () => {
+  let component
+
+  beforeEach(async () => {
+    mockCreateDistributionPromise.mockResolvedValueOnce({
+      Distribution: {
+        Id: 'distribution123'
+      }
+    })
+
+    component = await createComponent()
+  })
+
+  it('creates distribution with custom default behavior options', async () => {
+    await component.default({
+      defaults: {
+        ttl: 0,
+        forward: {
+          headers: ['Accept', 'Accept-Language'],
+          cookies: 'all',
+          queryString: true,
+          queryStringCacheKeys: ['query']
+        },
+        allowedHttpMethods: ['GET', 'HEAD', 'OPTIONS', 'PUT', 'POST', 'PATCH', 'DELETE'],
+        viewerProtocolPolicy: 'https-only',
+        smoothStreaming: true,
+        compress: true,
+        fieldLevelEncryptionId: '123'
+      },
+      origins: ['https://mycustomorigin.com']
+    })
+
+    expect(mockCreateDistribution.mock.calls[0][0]).toMatchSnapshot()
+  })
+
+  it('creates distribution with custom behavior options', async () => {
+    await component.default({
+      defaults: {
+        ttl: 0
+      },
+      origins: [
+        {
+          url: 'https://mycustomorigin.com',
+          pathPatterns: {
+            '/sample/path': {
+              ttl: 0,
+              forward: {
+                headers: 'all',
+                cookies: ['auth-token'],
+                queryString: true
+              },
+              allowedHttpMethods: ['GET', 'HEAD'],
+              viewerProtocolPolicy: 'redirect-to-https',
+              compress: false,
+              fieldLevelEncryptionId: '321'
+            }
+          }
+        }
+      ]
+    })
+
+    expect(mockCreateDistribution.mock.calls[0][0]).toMatchSnapshot()
+  })
+})

--- a/lib/cacheBahaviorUtils.js
+++ b/lib/cacheBahaviorUtils.js
@@ -1,0 +1,63 @@
+const forwardDefaults = {
+  cookies: 'none',
+  queryString: false
+}
+
+/**
+ * @param config User-defined config
+ * @param defaults Default framework values (default cache behavior and custom cache behavior have different default values)
+ * @returns Object
+ */
+function getForwardedValues(config = {}, defaults = {}) {
+  const defaultValues = { ...forwardDefaults, ...defaults }
+  const { cookies, queryString = defaultValues.queryString, headers, queryStringCacheKeys } = config
+
+  // Cookies
+  const forwardCookies = {
+    Forward: defaultValues.cookies
+  }
+
+  if (typeof cookies === 'string') {
+    forwardCookies.Forward = cookies
+  } else if (Array.isArray(cookies)) {
+    forwardCookies.Forward = 'whitelist'
+    forwardCookies.WhitelistedNames = {
+      Quantity: cookies.length,
+      Items: cookies
+    }
+  }
+
+  // Headers
+  const forwardHeaders = {
+    Quantity: 0,
+    Items: []
+  }
+
+  if (typeof headers === 'string' && headers === 'all') {
+    forwardHeaders.Quantity = 1
+    forwardHeaders.Items = ['*']
+  } else if (Array.isArray(headers)) {
+    forwardHeaders.Quantity = headers.length
+    forwardHeaders.Items = headers
+  }
+
+  // QueryStringCacheKeys
+  const forwardQueryKeys = {
+    Quantity: 0,
+    Items: []
+  }
+
+  if (Array.isArray(queryStringCacheKeys)) {
+    forwardQueryKeys.Quantity = queryStringCacheKeys.length
+    forwardQueryKeys.Items = queryStringCacheKeys
+  }
+
+  return {
+    QueryString: queryString,
+    Cookies: forwardCookies,
+    Headers: forwardHeaders,
+    QueryStringCacheKeys: forwardQueryKeys
+  }
+}
+
+module.exports = { getForwardedValues }

--- a/lib/getCacheBehavior.js
+++ b/lib/getCacheBehavior.js
@@ -1,22 +1,20 @@
+const { getForwardedValues } = require('./cacheBahaviorUtils')
+
 module.exports = (pathPattern, pathPatternConfig, originId) => {
-  const { ttl, allowedHttpMethods } = pathPatternConfig
-  const allowedMethods = allowedHttpMethods || ['GET', 'HEAD']
+  const {
+    allowedHttpMethods = ['GET', 'HEAD'],
+    ttl,
+    compress = true,
+    smoothStreaming = false,
+    viewerProtocolPolicy = 'https-only',
+    fieldLevelEncryptionId = ''
+  } = pathPatternConfig
 
   return {
-    ForwardedValues: {
-      Cookies: {
-        Forward: 'all'
-      },
-      QueryString: true,
-      Headers: {
-        Quantity: 0,
-        Items: []
-      },
-      QueryStringCacheKeys: {
-        Quantity: 0,
-        Items: []
-      }
-    },
+    ForwardedValues: getForwardedValues(pathPatternConfig.forward, {
+      cookies: 'all',
+      queryString: true
+    }),
     MinTTL: ttl,
     PathPattern: pathPattern,
     TargetOriginId: originId,
@@ -24,20 +22,20 @@ module.exports = (pathPattern, pathPatternConfig, originId) => {
       Enabled: false,
       Quantity: 0
     },
-    ViewerProtocolPolicy: 'https-only',
+    ViewerProtocolPolicy: viewerProtocolPolicy,
     AllowedMethods: {
-      Quantity: allowedMethods.length,
-      Items: allowedMethods,
+      Quantity: allowedHttpMethods.length,
+      Items: allowedHttpMethods,
       CachedMethods: {
         Items: ['GET', 'HEAD'],
         Quantity: 2
       }
     },
-    Compress: true,
-    SmoothStreaming: false,
+    Compress: compress,
+    SmoothStreaming: smoothStreaming,
     DefaultTTL: ttl,
     MaxTTL: ttl,
-    FieldLevelEncryptionId: '',
+    FieldLevelEncryptionId: fieldLevelEncryptionId,
     LambdaFunctionAssociations: {
       Quantity: 0,
       Items: []

--- a/lib/getDefaultCacheBehavior.js
+++ b/lib/getDefaultCacheBehavior.js
@@ -1,48 +1,44 @@
 const addLambdaAtEdgeToCacheBehavior = require('./addLambdaAtEdgeToCacheBehavior')
+const { getForwardedValues } = require('./cacheBahaviorUtils')
 
 module.exports = (originId, defaults = {}) => {
-  const allowedMethods = defaults.allowedHttpMethods || ['HEAD', 'GET']
+  const {
+    allowedHttpMethods = ['HEAD', 'GET'],
+    forward = {},
+    ttl = 86400,
+    compress = false,
+    smoothStreaming = false,
+    viewerProtocolPolicy = 'redirect-to-https',
+    fieldLevelEncryptionId = ''
+  } = defaults
 
   const defaultCacheBehavior = {
     TargetOriginId: originId,
-    ForwardedValues: {
-      QueryString: false,
-      Cookies: {
-        Forward: 'none'
-      },
-      Headers: {
-        Quantity: 0,
-        Items: []
-      },
-      QueryStringCacheKeys: {
-        Quantity: 0,
-        Items: []
-      }
-    },
+    ForwardedValues: getForwardedValues(forward),
     TrustedSigners: {
       Enabled: false,
       Quantity: 0,
       Items: []
     },
-    ViewerProtocolPolicy: 'redirect-to-https',
+    ViewerProtocolPolicy: viewerProtocolPolicy,
     MinTTL: 0,
     AllowedMethods: {
-      Quantity: allowedMethods.length,
-      Items: allowedMethods,
+      Quantity: allowedHttpMethods.length,
+      Items: allowedHttpMethods,
       CachedMethods: {
         Quantity: 2,
         Items: ['HEAD', 'GET']
       }
     },
-    SmoothStreaming: false,
-    DefaultTTL: defaults.ttl || 86400,
+    SmoothStreaming: smoothStreaming,
+    DefaultTTL: ttl,
     MaxTTL: 31536000,
-    Compress: false,
+    Compress: compress,
     LambdaFunctionAssociations: {
       Quantity: 0,
       Items: []
     },
-    FieldLevelEncryptionId: ''
+    FieldLevelEncryptionId: fieldLevelEncryptionId
   }
 
   addLambdaAtEdgeToCacheBehavior(defaultCacheBehavior, defaults['lambda@edge'])


### PR DESCRIPTION
This PR is discussed in #6. It adds more behavior parameters to both default and custom cache behaviors.

Existing tests are passing as I left the existing defaults intact, and I also added a new test with a snapshot. This was also tested manually on the project I 'm working on.

`README.md` also updated to expand the examples with new parameters.

@eahefnawy please review and let me know if you want to change something!