### PR TITLE
fixed removal of cloudfront distribution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -131,7 +131,7 @@ const updateCloudFrontDistribution = async (cf, s3, distributionId, inputs) => {
   }
 }
 
-const disableCloudFrontDistribution = async (cf, distributionId) => {
+const disableCloudFrontDistribution = async (cf, distributionId, debug) => {
   const params = await cf.getDistributionConfig({ Id: distributionId }).promise()
 
   params.IfMatch = params.ETag
@@ -143,27 +143,22 @@ const disableCloudFrontDistribution = async (cf, distributionId) => {
   params.DistributionConfig.Enabled = false
 
   const res = await cf.updateDistribution(params).promise()
+  debug(`Waiting for CloudFront distribution changes to be deployed.`)
+  await cf.waitFor('distributionDeployed', { Id: distributionId }).promise()
 
-  return {
-    id: res.Distribution.Id,
-    arn: res.Distribution.ARN,
-    url: `https://${res.Distribution.DomainName}`
-  }
+  return res
 }
 
-const deleteCloudFrontDistribution = async (cf, distributionId) => {
-  try {
-    const res = await cf.getDistributionConfig({ Id: distributionId }).promise()
+const deleteCloudFrontDistribution = async (cf, distributionId, debug) => {
+  let res = await cf.getDistributionConfig({ Id: distributionId }).promise()
 
-    const params = { Id: distributionId, IfMatch: res.ETag }
-    await cf.deleteDistribution(params).promise()
-  } catch (e) {
-    if (e.code === 'DistributionNotDisabled') {
-      await disableCloudFrontDistribution(cf, distributionId)
-    } else {
-      throw e
-    }
+  if (res.DistributionConfig.Enabled) {
+    debug(`Disabling CloudFront distribution of ID ${distributionId} before removal.`)
+    res = await disableCloudFrontDistribution(cf, distributionId, debug)
   }
+
+  const params = { Id: distributionId, IfMatch: res.ETag }
+  await cf.deleteDistribution(params).promise()
 }
 
 module.exports = {

--- a/serverless.js
+++ b/serverless.js
@@ -74,7 +74,10 @@ class CloudFront extends Component {
       region: this.state.region
     })
 
-    await deleteCloudFrontDistribution(cf, this.state.id)
+    this.context.debug(
+      `Removing CloudFront distribution of ID ${this.state.id}. It could take a while.`
+    )
+    await deleteCloudFrontDistribution(cf, this.state.id, this.context.debug)
 
     this.state = {}
     await this.save()


### PR DESCRIPTION
Previously active (enabled) distributions were never removed only disabled