### PR TITLE
Origin Custom Headers Support

### DIFF
--- a/__tests__/__snapshots__/origin-with-custom-headers.test.js.snap
+++ b/__tests__/__snapshots__/origin-with-custom-headers.test.js.snap
@@ -1,0 +1,149 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Input origin with custom header creates distribution with custom url origin 1`] = `
+Object {
+  "DistributionConfig": Object {
+    "Aliases": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "CacheBehaviors": Object {
+      "Items": Array [
+        Object {
+          "AllowedMethods": Object {
+            "CachedMethods": Object {
+              "Items": Array [
+                "GET",
+                "HEAD",
+              ],
+              "Quantity": 2,
+            },
+            "Items": Array [
+              "GET",
+              "HEAD",
+              "POST",
+            ],
+            "Quantity": 3,
+          },
+          "Compress": true,
+          "DefaultTTL": 10,
+          "FieldLevelEncryptionId": "",
+          "ForwardedValues": Object {
+            "Cookies": Object {
+              "Forward": "all",
+            },
+            "Headers": Object {
+              "Items": Array [],
+              "Quantity": 0,
+            },
+            "QueryString": true,
+            "QueryStringCacheKeys": Object {
+              "Items": Array [],
+              "Quantity": 0,
+            },
+          },
+          "LambdaFunctionAssociations": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "MaxTTL": 10,
+          "MinTTL": 10,
+          "PathPattern": "/some/path",
+          "SmoothStreaming": false,
+          "TargetOriginId": "exampleorigin.com",
+          "TrustedSigners": Object {
+            "Enabled": false,
+            "Quantity": 0,
+          },
+          "ViewerProtocolPolicy": "https-only",
+        },
+      ],
+      "Quantity": 1,
+    },
+    "CallerReference": "1566599541192",
+    "Comment": "",
+    "DefaultCacheBehavior": Object {
+      "AllowedMethods": Object {
+        "CachedMethods": Object {
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Items": Array [
+          "HEAD",
+          "GET",
+        ],
+        "Quantity": 2,
+      },
+      "Compress": false,
+      "DefaultTTL": 86400,
+      "FieldLevelEncryptionId": "",
+      "ForwardedValues": Object {
+        "Cookies": Object {
+          "Forward": "none",
+        },
+        "Headers": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "QueryString": false,
+        "QueryStringCacheKeys": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+      },
+      "LambdaFunctionAssociations": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "MaxTTL": 31536000,
+      "MinTTL": 0,
+      "SmoothStreaming": false,
+      "TargetOriginId": "exampleorigin.com",
+      "TrustedSigners": Object {
+        "Enabled": false,
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "ViewerProtocolPolicy": "redirect-to-https",
+    },
+    "Enabled": true,
+    "HttpVersion": "http2",
+    "Origins": Object {
+      "Items": Array [
+        Object {
+          "CustomHeaders": Object {
+            "Items": Array [
+              Object {
+                "HeaderName": "x-api-key",
+                "HeaderValue": "test",
+              },
+            ],
+            "Quantity": 1,
+          },
+          "CustomOriginConfig": Object {
+            "HTTPPort": 80,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginProtocolPolicy": "https-only",
+            "OriginReadTimeout": 30,
+            "OriginSslProtocols": Object {
+              "Items": Array [
+                "TLSv1.2",
+              ],
+              "Quantity": 1,
+            },
+          },
+          "DomainName": "exampleorigin.com",
+          "Id": "exampleorigin.com",
+          "OriginPath": "",
+        },
+      ],
+      "Quantity": 1,
+    },
+    "PriceClass": "PriceClass_All",
+  },
+}
+`;

--- a/__tests__/origin-with-custom-headers.test.js
+++ b/__tests__/origin-with-custom-headers.test.js
@@ -1,0 +1,52 @@
+const { createComponent, assertHasCacheBehavior, assertHasOrigin } = require('../test-utils')
+const { mockCreateDistribution, mockCreateDistributionPromise } = require('aws-sdk')
+
+describe('Input origin with custom header', () => {
+  let component
+
+  beforeEach(async () => {
+    mockCreateDistributionPromise.mockResolvedValueOnce({
+      Distribution: {
+        Id: 'xyz'
+      }
+    })
+
+    component = await createComponent()
+  })
+
+  it('creates distribution with custom url origin', async () => {
+    await component.default({
+      origins: [
+        {
+          url: 'https://exampleorigin.com',
+          pathPatterns: {
+            '/some/path': {
+              ttl: 10,
+              allowedHttpMethods: ['GET', 'HEAD', 'POST']
+            }
+          },
+          headers: {
+            'x-api-key': 'test'
+          }
+        }
+      ]
+    })
+
+    assertHasOrigin(mockCreateDistribution, {
+      Id: 'exampleorigin.com',
+      DomainName: 'exampleorigin.com',
+      CustomHeaders: {
+        Quantity: 1,
+        Items: [{ HeaderName: 'x-api-key', HeaderValue: 'test' }]
+      }
+    })
+
+    assertHasCacheBehavior(mockCreateDistribution, {
+      PathPattern: '/some/path',
+      MinTTL: 10,
+      TargetOriginId: 'exampleorigin.com'
+    })
+
+    expect(mockCreateDistribution.mock.calls[0][0]).toMatchSnapshot()
+  })
+})

--- a/lib/getOriginConfig.js
+++ b/lib/getOriginConfig.js
@@ -25,6 +25,14 @@ module.exports = (origin, { originAccessIdentityId = '' }) => {
         : ''
     }
   } else {
+    if (origin.headers) {
+      originConfig.CustomHeaders.Quantity = Object.keys(origin.headers).length
+      originConfig.CustomHeaders.Items = Object.keys(origin.headers).map((key) => ({
+        HeaderName: key,
+        HeaderValue: origin.headers[key]
+      }))
+    }
+
     originConfig.CustomOriginConfig = {
       HTTPPort: 80,
       HTTPSPort: 443,


### PR DESCRIPTION
I'm using this component for hosting a CF distribution that includes Appsync as an `/graphql` origin. Adding this feature will help me not having to have the `x-api-key` on the client itself.